### PR TITLE
fix(deps): shelljs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.6.7",
     "cross-spawn": "^7.0.3",
+    "shelljs": "^0.8.5",
     "tar": "^6.2.0"
   },
   "devDependencies": {
@@ -28,7 +29,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
-    "shelljs": "^0.8.5",
     "ts-jest": "^29.1.2",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"


### PR DESCRIPTION
seems like the "download" command requires shelljs to be installed

so it should be an production dependency

fixes #33